### PR TITLE
Fix skipped/miscalculated next crons + allow 1 minute interval

### DIFF
--- a/app/src/main/java/com/huishun/cronjobs/DetailsActivity.java
+++ b/app/src/main/java/com/huishun/cronjobs/DetailsActivity.java
@@ -45,6 +45,7 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.UUID;
@@ -156,15 +157,15 @@ public class DetailsActivity extends AppCompatActivity {
                     return;
                 }
 
-                if (Integer.parseInt(jobIntervalEdittext.getText().toString()) % 15 != 0
-                        && jobTimeUnitSpinner.getSelectedItemPosition() == 0
-                ) {
-                    Toast.makeText(
-                            DetailsActivity.this,
-                            "Please use 15-minute intervals",
-                            Toast.LENGTH_LONG).show();
-                    return;
-                }
+               if (Integer.parseInt(jobIntervalEdittext.getText().toString()) % 1 != 0
+                       && jobTimeUnitSpinner.getSelectedItemPosition() == 0
+               ) {
+                   Toast.makeText(
+                           DetailsActivity.this,
+                           "Please use 1-minute intervals",
+                           Toast.LENGTH_LONG).show();
+                   return;
+               }
 
                 if (jobParamsTextinput.getText().toString().length() > 0) {
                     try {
@@ -321,24 +322,10 @@ public class DetailsActivity extends AppCompatActivity {
 
     // have to calculate next run here to show it in main activity
     private String calcNextRun(JobModel job) {
-        long currentTime = new Date().getTime();
-        long fifteen = 15 * 60 * 1000;
-        long nextTime = (currentTime / fifteen + 1) * fifteen;
-//        Calendar calendar = Calendar.getInstance();
-//        calendar.setTime(new Date(nextTime));
-//        switch (job.getJobTimeUnit()) {
-//            case "hour":
-//                calendar.add(Calendar.HOUR, Integer.parseInt(job.getJobInterval()));
-//                break;
-//            case "day":
-//                calendar.add(Calendar.DATE, Integer.parseInt(job.getJobInterval()));
-//                break;
-//            default:
-//                calendar.add(Calendar.MINUTE, Integer.parseInt(job.getJobInterval()));
-//                break;
-//        }
-        String targetDate = Long.toString(nextTime);
-        return targetDate;
+        Calendar nextCalendar = Calendar.getInstance();
+        nextCalendar.add(Calendar.MINUTE, Integer.parseInt(job.getJobInterval()));
+
+        return Long.toString(nextCalendar.getTime().getTime());
     }
 
     public int createNotificationId(){

--- a/app/src/main/java/com/huishun/cronjobs/NewJobActivity.java
+++ b/app/src/main/java/com/huishun/cronjobs/NewJobActivity.java
@@ -121,15 +121,15 @@ public class NewJobActivity extends AppCompatActivity {
                             Toast.LENGTH_LONG).show();
                     return;
                 }
-                if (Integer.parseInt(jobIntervalEdittext.getText().toString()) % 15 != 0
-                        && jobTimeUnitSpinner.getSelectedItemPosition() == 0
-                ) {
-                    Toast.makeText(
-                            NewJobActivity.this,
-                            "Please use 15-minute intervals",
-                            Toast.LENGTH_LONG).show();
-                    return;
-                }
+               if (Integer.parseInt(jobIntervalEdittext.getText().toString()) % 1 != 0
+                       && jobTimeUnitSpinner.getSelectedItemPosition() == 0
+               ) {
+                   Toast.makeText(
+                           NewJobActivity.this,
+                           "Please use 1-minute intervals",
+                           Toast.LENGTH_LONG).show();
+                   return;
+               }
                 if (jobParamsTextinput.getText().toString().length() > 0) {
                     try {
                         new JSONObject(jobParamsTextinput.getText().toString());
@@ -162,7 +162,7 @@ public class NewJobActivity extends AppCompatActivity {
                 job.setJobNotifyError(jobNotifyErrorSwitch.isChecked() ? 1 : 0);
                 job.setJobNotifySuccess(jobNotifySuccessSwitch.isChecked() ? 1 : 0);
                 job.setJobResult("");
-                job.setJobNextRun(calcNextRun());
+                job.setJobNextRun(calcNextRun(job));
                 job.setJobRunCount(0);
                 job.setJobLastRun("1580897313933");
 
@@ -204,25 +204,11 @@ public class NewJobActivity extends AppCompatActivity {
         alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, targetTime.getTime(), pendingIntent);
     }
 
-    private String calcNextRun() {
-        long currentTime = new Date().getTime();
-        long fifteen = 15 * 60 * 1000;
-        long nextTime = (currentTime / fifteen + 1) * fifteen;
-//        Calendar calendar = Calendar.getInstance();
-//        calendar.setTime(new Date(nextTime));
-//        switch (job.getJobTimeUnit()) {
-//            case "hour":
-//                calendar.add(Calendar.HOUR, Integer.parseInt(job.getJobInterval()));
-//                break;
-//            case "day":
-//                calendar.add(Calendar.DATE, Integer.parseInt(job.getJobInterval()));
-//                break;
-//            default:
-//                calendar.add(Calendar.MINUTE, Integer.parseInt(job.getJobInterval()));
-//                break;
-//        }
-        String targetDate = Long.toString(nextTime);
-        return targetDate;
+    private String calcNextRun(JobModel job) {
+        Calendar nextCalendar = Calendar.getInstance();
+        nextCalendar.add(Calendar.MINUTE, Integer.parseInt(job.getJobInterval()));
+
+        return Long.toString(nextCalendar.getTime().getTime());
     }
 
     @Override

--- a/app/src/main/java/com/huishun/cronjobs/worker/AlarmReceiver.java
+++ b/app/src/main/java/com/huishun/cronjobs/worker/AlarmReceiver.java
@@ -58,7 +58,7 @@ public class AlarmReceiver extends BroadcastReceiver {
         Date jobLastRun;
 
         jobLastRun = new Date(Long.parseLong(job.getJobLastRun()));
-        if (TimeUnit.MILLISECONDS.toMinutes(currentDate.getTime() - jobLastRun.getTime()) < 10) { // call came in too early, probably a repeat call
+        if (TimeUnit.MILLISECONDS.toSeconds(currentDate.getTime() - jobLastRun.getTime()) < 30) { // call came in too early, probably a repeat call
             return;
         }
 
@@ -93,7 +93,7 @@ public class AlarmReceiver extends BroadcastReceiver {
 
         // while target time is not more than 10 minutes later than current time, increase the target time
         // this is in case one of previous job is missed
-        while (TimeUnit.MILLISECONDS.toMinutes(targetTime.getTime() - currentTime.getTime()) < 10) {
+        while (TimeUnit.MILLISECONDS.toSeconds(targetTime.getTime() - currentTime.getTime()) < 30) {
             switch (job.getJobTimeUnit()) {
                 case "hour":
                     nextCalendar.add(Calendar.HOUR, Integer.parseInt(job.getJobInterval()));

--- a/app/src/main/java/com/huishun/cronjobs/worker/OnBootReceiver.java
+++ b/app/src/main/java/com/huishun/cronjobs/worker/OnBootReceiver.java
@@ -66,7 +66,7 @@ public class OnBootReceiver extends BroadcastReceiver {
 
         // while target time is not more than 10 minutes later than current time, increase the target time
         // this is in case one of previous job is missed
-        while (TimeUnit.MILLISECONDS.toMinutes(targetTime.getTime() - currentTime.getTime()) < 0) {
+        while (TimeUnit.MILLISECONDS.toSeconds(targetTime.getTime() - currentTime.getTime()) < 30) {
             switch (job.getJobTimeUnit()) {
                 case "hour":
                     nextCalendar.add(Calendar.HOUR, Integer.parseInt(job.getJobInterval()));


### PR DESCRIPTION
Closes #1 

This is a quite "hacky version" based on what is currently implemented in the app.

I noticed that **before the change** it had many delays/errors when calculating the time; sometimes, it failed in intervals of more than 30 minutes.

With these new changes, the error rate is **lower** (not 0) when plugged into the AC or with no battery performance (at least for the test I'm doing right now using **healtchecks.io** in a 2-minute interval).

So this solves two things:

- Error running crons
- Allow any minute cron (not just 15 minutes)
- Unhardcode 15 minutes cron